### PR TITLE
Rewrite dragonbreath to support aoe dmg

### DIFF
--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -2526,7 +2526,7 @@ do_default:
 			}
 		case CHC_BREATH:
 			{
-                if (!strnicmp(ptcKey, "BREATH.MAXDIST", 14) || !strnicmp(ptcKey, "BREATH.DAM", 10))
+                if (!strnicmp(ptcKey, "BREATH.MAXDIST", 14) || !strnicmp(ptcKey, "BREATH.DAM", 10) || !strnicmp(ptcKey, "BREATH.COST", 11) || !strnicmp(ptcKey, "BREATH.AOE_SIZE", 15))
 				{
 					CVarDefCont * pVar = GetDefKey(ptcKey, true);
 					sVal.FormatLLVal(pVar ? pVar->GetValNum() : 0);
@@ -3824,7 +3824,7 @@ bool CChar::r_LoadVal( CScript & s )
 			break;
 		case CHC_BREATH:
 			{
-				if ( !strnicmp(ptcKey, "BREATH.MAXDIST", 14) || !strnicmp(ptcKey, "BREATH.DAM", 10) || !strnicmp(ptcKey, "BREATH.HUE", 10) || !strnicmp(ptcKey, "BREATH.ANIM", 11) || !strnicmp(ptcKey, "BREATH.TYPE", 11) || !strnicmp(ptcKey, "BREATH.DAMTYPE", 14))
+				if ( !strnicmp(ptcKey, "BREATH.MAXDIST", 14) || !strnicmp(ptcKey, "BREATH.DAM", 10) || !strnicmp(ptcKey, "BREATH.HUE", 10) || !strnicmp(ptcKey, "BREATH.ANIM", 11) || !strnicmp(ptcKey, "BREATH.TYPE", 11) || !strnicmp(ptcKey, "BREATH.DAMTYPE", 14) || !strnicmp(ptcKey, "BREATH.COST", 11) || !strnicmp(ptcKey, "BREATH.AOE_SIZE", 15))
 				{
 					SetDefNum(s.GetKey(), s.GetArgLLVal());
 					return true;

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -649,7 +649,14 @@ effect_bounce:
 		}
 
 		if ( (uiType & DAMAGE_FIRE) && Can(CAN_C_FIRE_IMMUNE) )
-			goto effect_bounce;
+		{
+			if ((uiType & ~DAMAGE_FIRE) == 0)
+			{
+				goto effect_bounce;
+			}
+			iDmg /= 2;
+			iDmgFire = 0;
+		}
 
 		// I can't take damage from my pets, the only exception is for BRAIN_BERSERK pets
 		//if ( pSrc->m_pNPC && (pSrc->NPC_PetGetOwner() == this) && (pSrc->m_pNPC->m_Brain != NPCBRAIN_BERSERK) )

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -3277,7 +3277,8 @@ int CChar::Skill_Act_Breath( SKTRIG_TYPE stage )
 
 	if ( stage == SKTRIG_START )
 	{
-		UpdateStatVal( STAT_DEX, -10 );
+		int const iBreathCost = static_cast<int>(GetDefNum("BREATH.COST", true, 10));
+		UpdateStatVal( STAT_DEX, -iBreathCost );
 		if ( !g_Cfg.IsSkillFlag( Skill_GetActive(), SKF_NOANIM ) )
 			UpdateAnimate( ANIM_MON_Stomp );
 
@@ -3317,7 +3318,7 @@ int CChar::Skill_Act_Breath( SKTRIG_TYPE stage )
 	ITEMID_TYPE id = (ITEMID_TYPE)(GetDefNum("BREATH.ANIM", true));
 	EFFECT_TYPE effect = static_cast<EFFECT_TYPE>(GetDefNum("BREATH.TYPE",true));
 	DAMAGE_TYPE iDmgType = (DAMAGE_TYPE)(GetDefNum("BREATH.DAMTYPE", true));
-
+	int const iAoeSize = static_cast<int>(GetDefNum("BREATH.AOE_SIZE", true, 1));
 	/* AOS damage types (used by COMBAT_ELEMENTAL_ENGINE)*/
 	int iDmgPhysical = 0, iDmgFire = 0, iDmgCold = 0, iDmgPoison = 0, iDmgEnergy = 0;
 
@@ -3343,7 +3344,28 @@ int CChar::Skill_Act_Breath( SKTRIG_TYPE stage )
 
 	Sound( 0x227 );
 	pChar->Effect( effect, id, this, 20, 30, false, hue );
+	if (iAoeSize > 1)
+	{
+		auto AreaChars = CWorldSearchHolder::GetInstance(m_Act_p, iAoeSize);
+		for (;;)
+		{
+			CChar* pCharInArea = AreaChars->GetChar();
+			if (!pCharInArea)
+				break;
+			if (pCharInArea->Fight_CanHit(this,true) == WAR_SWING_INVALID)    //Check if target can be hit (I am invul, stone etc. Target is Disconnected,safe zone etc)
+				continue;
+			if (pCharInArea->Noto_CalcFlag(this) == NOTO_GOOD)                //Avoid to hit someone we can't legally attack (same guild, same party, Vendor etc)
+				continue;
+			if (!pCharInArea->CanSeeLOS(this))                                //Avoid hit someone in nearby house
+				continue;
+
+			pCharInArea->OnTakeDamage( iDamage, this, iDmgType, iDmgPhysical, iDmgFire, iDmgCold, iDmgPoison, iDmgEnergy);
+		}
+
+		return 0;
+	}
 	pChar->OnTakeDamage( iDamage, this, iDmgType, iDmgPhysical, iDmgFire, iDmgCold, iDmgPoison, iDmgEnergy);
+
 	return 0;
 }
 


### PR DESCRIPTION
Fix CAN_C_FIRE_IMMUNE to mitigate only half damage when other type is present

Pridane BREATH.COST a BREATH.AOE_SIZE  ako mozne konfiguracie flusania drakov -> breath ide mimo beznych tirggerov a je hardcoded cez cost sa da ovladat ako casto bude pouzivat abilitu kedze je hardcoded ze ju pouzije vzdy, ked ma FULL staminu 