### PR TITLE
Fix/spellcasting npc

### DIFF
--- a/src/game/chars/CCharNPC.cpp
+++ b/src/game/chars/CCharNPC.cpp
@@ -340,4 +340,6 @@ void CChar::NPC_CreateTrigger()
 		if (iRet != TRIGRET_RET_FALSE && iRet != TRIGRET_RET_DEFAULT)
 			return;
 	}
+	if (m_pNPC)
+		NPC_GetAllSpellbookSpells();
 }


### PR DESCRIPTION
Jediny bod kedy sa prevolava pri NPC nacitanie spellov zo spellbooku je ked sa loaduje script/worldsave preto necastia.
Takto sa loadnu aj pri volani ON=@Create triggeru -> TEVENTS -> PETEVENTS(@Create na LINK ref) a nasledne sa pokusi loadnut spellbook.. 
v naslednosti treba presunut create spellbooku z @NPCRestock triggeru do create a to z dovodu, ze pri kreovani summonov a myslim ze aj respawne NPC sa z nejakeho dovodiu @NPCRestock trigger nevola