### PR TITLE
Fix summon menu overwriting active spell target

### DIFF
--- a/src/game/clients/CClient.cpp
+++ b/src/game/clients/CClient.cpp
@@ -1551,11 +1551,10 @@ bool CClient::r_Verb( CScript & s, CTextConsole * pSrc ) // Execute command from
 			if ( !pSpellDef )
 				return false;
 
-			m_pChar->m_Act_UID = m_pChar->GetUID();
-			m_pChar->m_Act_Prv_UID = m_pChar->GetUID();
-
 			if ( pSpellDef->IsSpellType(SPELLFLAG_TARG_OBJ|SPELLFLAG_TARG_XYZ) )
 			{
+				// Keep the character action context untouched until the summon target is selected.
+				// It may still belong to another spell currently waiting for its cast delay.
 				m_tmSkillMagery.m_iSpell = SPELL_Summon;
 				m_tmSkillMagery.m_uiSummonID = (CREID_TYPE)(g_Cfg.ResourceGetIndexType(RES_CHARDEF, s.GetArgStr()));
 
@@ -1572,6 +1571,8 @@ bool CClient::r_Verb( CScript & s, CTextConsole * pSrc ) // Execute command from
 			}
 			else
 			{
+				m_pChar->m_Act_UID = m_pChar->GetUID();
+				m_pChar->m_Act_Prv_UID = m_pChar->GetUID();
 				m_pChar->m_atMagery.m_iSpell = SPELL_Summon;
 				m_pChar->m_atMagery.m_uiSummonID = (CREID_TYPE)(g_Cfg.ResourceGetIndexType(RES_CHARDEF, s.GetArgStr()));
 


### PR DESCRIPTION
• ## Description

  Fixes an issue where opening the summon target selection menu overwrote the character’s active action context while another spell was still waiting for its
  cast delay.

  For targeted summons, m_Act_UID and m_Act_Prv_UID are now left unchanged until the summon target is selected. Non-targeted summons retain the existing behavior
  of setting both values to the casting character.

  This prevents the summon menu from corrupting the target information of an active spell.

  ———

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Performance improvement
  - [ ] Refactoring
  - [ ] Documentation update
  - [ ] Build / CI change
  - [ ] Other (please describe)

  ———

  ## Related Issues

  None.

  ———

  ## Testing

  - [ ] Tested on a clean SphereServer instance with latest ScriptPack
  - [ ] No regressions in existing functionality
  - [ ] Added or updated tests (if applicable)

  ———

  ## Checklist

  - [x] Code compiles successfully
  - [x] Changes follow the project's coding style
  - [x] No unrelated code was modified
  - [x] Documentation updated where necessary (not applicable)
  - [x] This PR does not introduce breaking changes

  ———

  ## Additional Notes

  The PR consists of one commit and changes only src/game/clients/CClient.cpp.

  Local uncommitted changes present in the working tree are not part of this PR.