### PR TITLE
Fix mounted and shrunken NPC position sync

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4131,3 +4131,7 @@ When setting a property like MORE to the a spell or skill defname, trying to rea
 
 02-04-2026, Mulambo
 - Fixed: Timer on field spells with `SPELLFLAG_FIELD_RANDOMDECAY` was incrementally increasing for each field item created.
+
+11-08-2026
+- Fixed: World saves and garbage collection could fire region/location triggers on mounted or shrunken NPCs, killing pets or leaving mounts at stale positions.
+- Fixed: The hidden NPC representation of an equipped mount now follows its rider without entering the normal gameplay movement pipeline.

--- a/src/game/CSector.cpp
+++ b/src/game/CSector.cpp
@@ -1015,6 +1015,26 @@ void CSector::MoveItemToSector( CItem * pItem )
     }
 }
 
+void CSector::CheckCharSaveParity(CChar* pChar)
+{
+    ADDTOCALLSTACK("CSector::CheckCharSaveParity");
+    ASSERT(pChar);
+
+    if ((pChar->IsStatFlag(STATF_SAVEPARITY) == m_fSaveParity) || !g_World.IsSaving())
+        return;
+
+    if (m_fSaveParity == g_World.m_fSaveParity)
+    {
+        // The destination sector has already been saved. Save the char before moving it there.
+        pChar->r_WriteParity(pChar->m_pPlayer ? g_World.m_FilePlayers : g_World.m_FileWorld);
+    }
+    else
+    {
+        // The destination sector has not been saved yet. Save it before adding the char.
+        r_Write();
+    }
+}
+
 bool CSector::MoveCharToSector( CChar * pChar )
 {
 	ADDTOCALLSTACK("CSector::MoveCharToSector");
@@ -1025,26 +1045,7 @@ bool CSector::MoveCharToSector( CChar * pChar )
 	if (IsCharActiveIn(pChar))
 		return false;
 
-	// Check my save parity vs. this sector's
-	if ( pChar->IsStatFlag( STATF_SAVEPARITY ) != m_fSaveParity )
-	{
-		if ( g_World.IsSaving())
-		{
-			if ( m_fSaveParity == g_World.m_fSaveParity )
-			{
-				// Save out the CChar now. the sector has already been saved.
-				if ( pChar->m_pPlayer )
-					pChar->r_WriteParity(g_World.m_FilePlayers);
-				else
-					pChar->r_WriteParity(g_World.m_FileWorld);
-			}
-			else
-			{
-				// We need to write out this CSector now. (before adding client)
-				r_Write();
-			}
-		}
-	}
+	CheckCharSaveParity(pChar);
 
 	// Remove from previous spot.
 	m_Chars_Active.AddCharActive(pChar);
@@ -1081,6 +1082,22 @@ bool CSector::MoveCharToSector( CChar * pChar )
         }
     }
 
+	return true;
+}
+
+bool CSector::MoveDisconnectedCharToSector(CChar* pChar)
+{
+	ADDTOCALLSTACK("CSector::MoveDisconnectedCharToSector");
+	ASSERT(pChar);
+	ASSERT(pChar->IsDisconnected());
+
+	if (IsCharDisconnectedIn(pChar))
+		return false;
+
+	m_Chars_Disconnect.AddCharDisconnected(pChar);
+	ASSERT(IsCharDisconnectedIn(pChar));
+	ASSERT(pChar->IsDisconnected());
+	CheckCharSaveParity(pChar);
 	return true;
 }
 
@@ -1511,4 +1528,3 @@ int64 CSector::GetLastClientTime() const
 {
 	return m_Chars_Active.GetTimeLastClient() ;
 }
-

--- a/src/game/CSector.h
+++ b/src/game/CSector.h
@@ -40,6 +40,7 @@ private:
 	bool IsMoonVisible( uint iPhase, int iLocalTime ) const;
 	void SetDefaultWeatherChance();
     bool IsInDungeon() const;
+    void CheckCharSaveParity(CChar* pChar);
 
 public:
 	CSector();
@@ -103,6 +104,7 @@ public:		virtual bool IsDeleted() const override;
 	size_t GetClientsNumber() const;
 	int64 GetLastClientTime() const;
 	bool MoveCharToSector(CChar* pChar);
+	bool MoveDisconnectedCharToSector(CChar* pChar);
 
 	bool _CanSleep(bool fCheckAdjacents) const;
 	void SetSectorWakeStatus();	// Ships may enter a sector before it's riders !

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -959,18 +959,17 @@ int CChar::FixWeirdness()
 				return iResultCode;
 			}
 
-			const CItem * pFigurine = Horse_GetValidMountItem();
-			if ( pFigurine == nullptr )
+			if (!_SyncRiddenPositionFromAnchor(true))
 			{
+				CItem* pLinkedItem = m_atRidden.m_uidFigurine.ItemFind();
+				const CObjBaseTemplate* pAnchor = pLinkedItem ? pLinkedItem->GetTopLevelObj() : nullptr;
+				g_Log.EventError("Ridden NPC (UID=0%x, id=0%x '%s') could not be synchronized without triggers. P=%s, ACTARG1=0%x, itemtype=%d, anchor=0%x, flags=0%" PRIx64 ", action=%d, disconnected=%d, servermode=%d.\n",
+					(dword)GetUID(), GetIDCommon(), GetName(), GetTopPoint().WriteUsed(),
+					(dword)m_atRidden.m_uidFigurine, pLinkedItem ? (int)pLinkedItem->GetType() : -1,
+					pAnchor ? (dword)pAnchor->GetUID() : 0, _uiStatFlag, (int)Skill_GetActive(),
+					(int)IsDisconnected(), (int)g_Serv.GetServerMode());
 				iResultCode = 0x1204;
 				return iResultCode;
-			}
-
-			const CPointMap& pt = pFigurine->GetTopLevelObj()->GetTopPoint();
-			if ( pt != GetTopPoint())
-			{
-				MoveToChar( pt, true, true );
-				SetDisconnected();
 			}
 		}
 	}
@@ -4143,7 +4142,10 @@ void CChar::r_Write( CScript & s )
 	if ( m_pNPC )
 		m_pNPC->r_WriteChar(this, s);
 
-	const CPointMap& pt = GetTopPoint();
+	CPointMap pt(GetTopPoint());
+	CPointMap ptAnchor;
+	if (IsStatFlag(STATF_RIDDEN) && _GetRiddenAnchorPoint(ptAnchor))
+		pt = ptAnchor;
 	if (pt.IsValidPoint())
 		s.WriteKeyStr("P", pt.WriteUsed());
 

--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -1180,6 +1180,10 @@ public:
 private:
     [[nodiscard]]
     CItem* Horse_ValidateMountItem(CItem *pMountItem) const;
+	bool _GetRiddenAnchorPoint(CPointMap& ptAnchor) const;
+	bool _RelocateDisconnectedNoTriggers(const CPointMap& pt);
+	bool _SyncRiddenPositionFromAnchor(bool fAttemptRepair);
+	void _SyncEquippedMountPosition();
 
     CItem* Horse_GetMountItem() const;
     CChar* Horse_GetMountChar() const;

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3715,6 +3715,84 @@ CItem* CChar::Horse_ValidateMountItem(CItem *pMountItem) const
 
 }
 
+bool CChar::_GetRiddenAnchorPoint(CPointMap& ptAnchor) const
+{
+	ADDTOCALLSTACK("CChar::_GetRiddenAnchorPoint");
+
+	if (!IsStatFlag(STATF_RIDDEN) || !IsDisconnected() || (Skill_GetActive() != NPCACT_RIDDEN))
+		return false;
+
+	CItem* pMountItem = Horse_GetMountItem();
+	if (!pMountItem)
+		return false;
+
+	const CObjBaseTemplate* pAnchor = pMountItem->GetTopLevelObj();
+	if (!pAnchor)
+		return false;
+
+	ptAnchor = pAnchor->GetTopPoint();
+	return ptAnchor.IsValidPoint();
+}
+
+bool CChar::_RelocateDisconnectedNoTriggers(const CPointMap& pt)
+{
+	ADDTOCALLSTACK("CChar::_RelocateDisconnectedNoTriggers");
+
+	if (!IsDisconnected() || !pt.IsValidPoint())
+		return false;
+
+	CSector* pNewSector = pt.GetSector();
+	if (!pNewSector)
+		return false;
+
+	// Internal bookkeeping only: disconnected chars must not enter the normal
+	// movement pipeline or fire region, room, environment or location triggers.
+	SetUnkPoint(pt);
+	if (!pNewSector->IsCharDisconnectedIn(this))
+		pNewSector->MoveDisconnectedCharToSector(this);
+
+	ASSERT(IsDisconnected());
+	ASSERT(pNewSector->IsCharDisconnectedIn(this));
+	ASSERT(GetTopPoint() == pt);
+	return IsDisconnected() && pNewSector->IsCharDisconnectedIn(this) && (GetTopPoint() == pt);
+}
+
+bool CChar::_SyncRiddenPositionFromAnchor(bool fAttemptRepair)
+{
+	ADDTOCALLSTACK("CChar::_SyncRiddenPositionFromAnchor");
+
+	if (!IsStatFlag(STATF_RIDDEN) || !IsDisconnected() || (Skill_GetActive() != NPCACT_RIDDEN))
+		return false;
+
+	CItem* pMountItem = fAttemptRepair ? Horse_GetValidMountItem() : Horse_GetMountItem();
+	if (!pMountItem)
+		return false;
+
+	const CObjBaseTemplate* pAnchor = pMountItem->GetTopLevelObj();
+	if (!pAnchor)
+		return false;
+
+	return _RelocateDisconnectedNoTriggers(pAnchor->GetTopPoint());
+}
+
+void CChar::_SyncEquippedMountPosition()
+{
+	ADDTOCALLSTACK("CChar::_SyncEquippedMountPosition");
+
+	if (!IsStatFlag(STATF_ONHORSE))
+		return;
+
+	CItem* pMountItem = LayerFind(LAYER_HORSE);
+	if (!pMountItem || !pMountItem->IsType(IT_EQ_HORSE))
+		return;
+
+	CChar* pMount = pMountItem->m_itFigurine.m_UID.CharFind();
+	if (!pMount || (pMount->Horse_ValidateMountItem(pMountItem) != pMountItem))
+		return;
+
+	pMount->_RelocateDisconnectedNoTriggers(GetTopPoint());
+}
+
 // I am a horse.
 // Get my mount object. (attached to my rider)
 CItem* CChar::Horse_GetMountItem() const
@@ -4021,6 +4099,7 @@ bool CChar::Horse_Mount(CChar *pHorse)
 
     pHorse->StatFlag_Set(STATF_RIDDEN);
 	pHorse->Skill_Start(NPCACT_RIDDEN);
+	_SyncEquippedMountPosition();
 	return true;
 }
 
@@ -4058,6 +4137,7 @@ bool CChar::Horse_UnMount()
 	}
 	else
 	{
+		_SyncEquippedMountPosition();
 		Use_Figurine(pMountItem, false);
 		pMountItem->Delete();
 		/*
@@ -5334,6 +5414,7 @@ bool CChar::MoveToChar(const CPointMap& pt, bool fStanding, bool fCheckLocationE
 		SetDisconnected(pSector);
         SetTopPoint(pt); // This will clear the disconnected UID flag and the set the character position in the world.
 		SetDisconnected(); //Before entering here the player is not considered disconnected anymore, so we need to disconnect it again.
+		_SyncEquippedMountPosition();
 		return true;
 	}
 
@@ -5374,8 +5455,10 @@ bool CChar::MoveToChar(const CPointMap& pt, bool fStanding, bool fCheckLocationE
     if (fCheckLocationEffects && (CheckLocationEffects(fStanding) == TRIGRET_RET_FALSE) && ptOld.IsValidPoint())
     {
         SetTopPoint(ptOld);
+		_SyncEquippedMountPosition();
         return false;
     }
+	_SyncEquippedMountPosition();
 	return true;
 }
 
@@ -5392,6 +5475,7 @@ void CChar::SetTopZ( char z )
 	CObjBaseTemplate::SetTopZ( z );
 	m_fClimbUpdated = false; // update climb height
 	FixClimbHeight();	// can throw an exception
+	_SyncEquippedMountPosition();
 }
 
 // Move from here to a valid spot.


### PR DESCRIPTION
## Description

  Fixes position synchronization issues affecting mounted and shrunken NPCs during world saves and garbage collection.

  The hidden NPC representation of an equipped mount could remain at a stale position after its rider moved. During garbage collection, the server attempted to
  correct this through the normal movement pipeline. This could execute region, location, and environmental triggers for the hidden NPC, potentially killing or
  releasing the mount and automatically dismounting its rider.

  The changes:

  - Keep the hidden mount NPC synchronized with its rider.
  - Relocate disconnected mounted or shrunken NPCs without executing gameplay movement triggers.
  - Preserve world-save parity when moving disconnected NPCs between sectors.
  - Save ridden NPCs using the position of their linked figurine or mounted rider.
  - Improve diagnostic logging when a ridden NPC cannot be synchronized.

  ———

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Performance improvement
  - [ ] Refactoring
  - [ ] Documentation update
  - [ ] Build / CI change
  - [ ] Other (please describe)

  ———

  ## Related Issues

  None.

  ———

  ## Testing

  - [x] Tested on a clean SphereServer instance with latest ScriptPack
  - [x] No regressions in existing functionality
  - [ ] Added or updated tests (not applicable; no automated test coverage was added)

  Manual testing confirmed the previous behavior where the hidden mount NPC remained at a stale position after its rider moved. Sector sleeping, activation,
  garbage collection, and background world-save scenarios were also exercised.

  ———

  ## Checklist

  - [x] Code compiles successfully
  - [x] Changes follow the project's coding style
  - [x] No unrelated code was modified
  - [x] Documentation updated where necessary
  - [x] This PR does not introduce breaking changes

  ———

  ## Additional Notes

  The fix intentionally bypasses normal region, room, environmental, and location triggers when synchronizing disconnected mounted or shrunken NPCs. This
  relocation is internal bookkeeping and should not behave as normal gameplay movement.

  The changelog has been updated to document the corrected world-save, garbage-collection, and mount-position behavior.